### PR TITLE
Revert to using profile on the main agents page

### DIFF
--- a/app/views/v3/availability-management/agents/agent-profiles.html
+++ b/app/views/v3/availability-management/agents/agent-profiles.html
@@ -143,7 +143,7 @@ Select agents - GOV.UK prototype
         
 
             <h1 class="govuk-heading-l" style="padding-top:10px;">
-              HCP locations and skills
+              HCP profiles
             
            
             </h1>
@@ -400,7 +400,7 @@ Select agents - GOV.UK prototype
           <a class="moj-pagination__link" href=" ">Next<span class="govuk-visually-hidden"> page</span></a>
         </li>
       </ul>
-      <p class="moj-pagination__results" style="padding-left: 0px; width:50%; float: right;  text-align: right; margin-top:-5px;">Showing <b>1</b> to <b>10</b> of <b>12</b> HCPs</p>
+      <p class="moj-pagination__results" style="padding-left: 0px; width:50%; float: right;  text-align: right; margin-top:-5px;">Showing <b>1</b> to <b>10</b> of <b>12</b> HCP profiles</p>
     </nav>
 
        </div>

--- a/app/views/v3/availability-management/agents/no-agents-availability.html
+++ b/app/views/v3/availability-management/agents/no-agents-availability.html
@@ -37,14 +37,14 @@ Select agents - GOV.UK prototype
         
 
             <h1 class="govuk-heading-l" style="padding-top:10px;">
-              HCP profiles
+              Appointment availability
             
            
             </h1>
          
 
      
-<p>There are no HCP profiles available yet.</p>
+<p>There are no HCP profiles available to assign to appointments.</p>
     
     </div>
 

--- a/app/views/v3/availability-management/agents/no-location-agents.html
+++ b/app/views/v3/availability-management/agents/no-location-agents.html
@@ -144,14 +144,15 @@ Select agents - GOV.UK prototype
         
 
             <h1 class="govuk-heading-l" style="padding-top:10px;">
-              HCP locations and skills
+              HCP profiles
             
            
             </h1>
+            <h2 class="govuk-heading-m">No profiles found</h2>
          
 
             
-          <p>There are no agents to show in this location.</p>
+          <p>Adjust the filters to include more profiles.</p>
 
      
 

--- a/app/views/v3/availability-management/manage-select.html
+++ b/app/views/v3/availability-management/manage-select.html
@@ -34,14 +34,14 @@ Prototype page title
 
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <h1 class="govuk-fieldset__heading">
-            Manage HCPs or availability 
+            Manage availability 
           </h1>
         </legend>
         <div class="govuk-radios" data-module="govuk-radios">
           <div class="govuk-radios__item">
             <input class="govuk-radios__input" id="manage" name="manage" type="radio" value="agents">
             <label class="govuk-label govuk-radios__label" for="manage">
-              HCP locations and skills
+              HCP profiles
             </label>
           </div>
           <div class="govuk-radios__item">


### PR DESCRIPTION
This is because we can't save plural forms in the database so we can't use the role description as the primary noun alone.

Also added an availability error - but need to know if it's really an error page or not.