### PR TITLE
Removed dynamic content from success banner

### DIFF
--- a/app/views/v3/availability-management/availability/existing-slots-added.html
+++ b/app/views/v3/availability-management/availability/existing-slots-added.html
@@ -41,7 +41,7 @@ Availability - GOV.UK prototype
             <h3 class="govuk-notification-banner__heading">
             Appointment availability added
           </h3>
-          <p class="govuk-body">You can now book appointments with the chosen HCPs.</p>
+          <p class="govuk-body">You can now book appointments with the chosen people.</p>
            
             
         


### PR DESCRIPTION
Singular / plural issue (HCPs versus work coaches) - I can't just add an s.