### PR TITLE
Content for notification banner

### DIFF
--- a/app/views/v6/errors/agent-edit-appt-booked.html
+++ b/app/views/v6/errors/agent-edit-appt-booked.html
@@ -24,10 +24,10 @@ Home – {{serviceName}} – GOV.UK Prototype Kit
       
        
        
-      <div class="govuk-notification-banner__content" style="max-width: 655px !important;">
-        <p class="govuk-notification-banner__heading" style="max-width: 655px !important;">Availability could not be added for everyone</p>
+      <div class="govuk-notification-banner__content" >
+        <p class="govuk-notification-banner__heading" style="white-space:nowrap !important;">Availability could not be changed for everyone on Monday 11 March 2024</p>
         <ul class="govuk-list govuk-list--bullet"><li>[agent name]</li></ul>
-        <p><a href="">View booked appointments</a> to cancel their appointment.</p>
+        <p style="white-space:nowrap !important;"><a href="" >View booked appointments</a> to cancel any affected appointments before making any changes.</p>
        </div>
        
         


### PR DESCRIPTION
First pass at content for when we cannot change existing availability because an appointment is already booked at that time (and we can't re-assign in the Hawk space yet).